### PR TITLE
Add: experiment tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /external/proteina/proteina_training_data_indices
 /external/proteina/data
 /external/proteina/openfold
+/results
 
 /references
 # Data

--- a/docs/TECHNICAL_EXPLANATION.md
+++ b/docs/TECHNICAL_EXPLANATION.md
@@ -1,6 +1,5 @@
 # Protein Design Pipeline: Technical Documentation
 TO-DO list:
-- add experiment tracking tool (MLFlow)
 - Run experiments
 - Run final pipeline 
 - Update documentation

--- a/pipeline/main.nf
+++ b/pipeline/main.nf
@@ -1,5 +1,5 @@
 
-// --- 2. PROCESSES ---
+// --- 1. PROCESSES ---
 
 process GENERATE_BACKBONES {
     conda "${params.proteina_env}"
@@ -54,7 +54,6 @@ process RUN_MPNN {
 }
 
 process RUN_CATHE {
-    publishDir "final_results", mode: 'copy'
     beforeScript "source ${params.cathe_venv}/bin/activate"
 
     input:
@@ -94,7 +93,6 @@ process RUN_CATHE {
 
 process GENERATE_REPORT {
     conda "${params.protein_design_env}"
-    publishDir "final_results", mode: 'copy'
 
     input:
     path csv_file
@@ -109,19 +107,55 @@ process GENERATE_REPORT {
     """
 }
 
-// --- 3. WORKFLOW ---
+process LOG_RUN {
+    conda "${params.protein_design_env}"
+
+    input:
+    path classifications_csv
+    path report_html
+    path top_designs_csv
+
+    output:
+    path "metrics.json"
+
+    script:
+    """
+    python3 << 'EOF'
+import json
+params = {
+    "proteina": {
+        "nsamples": ${params.proteina.nsamples},
+        "seed": ${params.proteina.seed},
+        "nres_lens": "${params.proteina.nres_lens.join(',')}",
+        "autoguidance_ratio": ${params.proteina.autoguidance_ratio},
+        "dt": ${params.proteina.dt},
+        "guidance_weight": ${params.proteina.guidance_weight},
+        "sampling_mode": "${params.proteina.sampling_mode}",
+        "caflow_noise_scale": ${params.proteina.caflow_noise_scale}
+    },
+    "mpnn": {
+        "num_seq_per_target": ${params.mpnn.num_seq_per_target},
+        "sampling_temp": ${params.mpnn.sampling_temp}
+    },
+    "results_dir": "${params.results_dir}"
+}
+with open("run_params.json", "w") as f:
+    json.dump(params, f)
+EOF
+
+    python ${params.project_root}/src/log_run.py ${classifications_csv} run_params.json ${report_html} ${top_designs_csv}
+    python ${params.project_root}/src/compute_metrics.py ${classifications_csv} > metrics.json
+    """
+}
+
+// --- 2. WORKFLOW ---
 
 workflow {
     backbones_ch = GENERATE_BACKBONES()
-    
-    // Flatten turns the list of PDBs into a stream of individual files
     pdb_ch = backbones_ch.pdbs.flatten()
-
-    // Pass the channel itself, not .pdbs
     fastas_ch = RUN_MPNN(pdb_ch)
-
-    // Collect all FASTAs into one list so CATHe runs ONCE on the whole batch
     cathe_results_ch = RUN_CATHE(fastas_ch.fastas.collect())
 
-    GENERATE_REPORT(cathe_results_ch)
+    report_ch = GENERATE_REPORT(cathe_results_ch)
+    LOG_RUN(cathe_results_ch, report_ch.html, report_ch.csv)
 }

--- a/pipeline/nextflow.config
+++ b/pipeline/nextflow.config
@@ -3,6 +3,7 @@ nextflow.enable.dsl=2
 // --- GLOBAL PARAMETERS ---
 // params.project_root = "${workflow.projectDir.parent}"
 params.project_root = "${baseDir}/.."
+params.results_dir = "${baseDir}/../results"
 
 // Environment Paths
 params.protein_design_env = "/opt/miniconda3/envs/protein_design_env"

--- a/src/compute_metrics.py
+++ b/src/compute_metrics.py
@@ -1,0 +1,62 @@
+# compute_metrics.py
+import pandas as pd
+import json
+from pathlib import Path
+
+def compute_metrics(csv_path, target_fold="2.60.40"):
+    """
+    Compute metrics from sequences CSV
+    """
+
+    df = pd.read_csv(csv_path)
+    df["sequence_length"] = df["Sequence"].str.len()
+    
+    
+    # Overall metrics
+    total = len(df)
+    target_fold_count = (df['CATHe_Predicted_SFAM'].str.startswith(target_fold)).sum()
+    target_fold_high_conf = (
+        (df['CATHe_Predicted_SFAM'].str.startswith(target_fold)) & 
+        (df['CATHe_Prediction_Probability'] > 0.7)
+    ).sum()
+    
+    df_2_60_40 = df[df['CATHe_Predicted_SFAM'].str.startswith(target_fold)]
+
+    metrics = {
+        'overall': {
+            'target_fold_count': int(target_fold_count),
+            'pct_target_fold': round(100 * target_fold_count / total, 2),
+            'pct_target_fold_high_conf': round(100 * target_fold_high_conf / total, 2),
+            'mean_probability': round(df_2_60_40['CATHe_Prediction_Probability'].mean(), 4),
+            'median_probability': round(df_2_60_40['CATHe_Prediction_Probability'].median(), 4),
+        },
+        'per_length': {}
+    }
+    
+    # Per-length stratification
+    for length in sorted(df['sequence_length'].unique()):
+        df_len = df[df['sequence_length'] == length]
+        df_len_2_60_40 = df_len[df_len['CATHe_Predicted_SFAM'].str.startswith(target_fold)]
+        n = len(df_len)
+        target_fold_n = (df_len['CATHe_Predicted_SFAM'].str.startswith(target_fold)).sum()
+        target_fold_hc_n = (
+            (df_len['CATHe_Predicted_SFAM'].str.startswith(target_fold)) & 
+            (df_len['CATHe_Prediction_Probability'] > 0.7)
+        ).sum()
+        
+        metrics['per_length'][int(length)] = {
+            'target_fold_count': int(target_fold_n),
+            'pct_target_fold': round(100 * target_fold_n / n, 2) if n > 0 else 0,
+            'pct_target_fold_high_conf': round(100 * int(target_fold_hc_n) / n, 2) if n > 0 else 0,
+            'mean_probability': round(df_len_2_60_40['CATHe_Prediction_Probability'].mean(), 4),
+            'median_probability': round(df_len_2_60_40['CATHe_Prediction_Probability'].median(), 4),
+
+        }
+    
+    return metrics
+
+if __name__ == '__main__':
+    import sys
+    csv_path = sys.argv[1]
+    metrics = compute_metrics(csv_path)
+    print(json.dumps(metrics, indent=2))

--- a/src/experiment_analysis.ipynb
+++ b/src/experiment_analysis.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ba2b08d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "998be195",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(\"../results/experiments.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "900b767e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.head()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "protein_design_env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/generate_report.py
+++ b/src/generate_report.py
@@ -116,9 +116,6 @@ def generate_report(csv_path):
 
     df_26040.to_csv("top_designs.csv", index=False)
 
-    abs_path = os.path.abspath("report.html")
-    webbrowser.open(f'file://{abs_path}')
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--input", required=True)

--- a/src/log_run.py
+++ b/src/log_run.py
@@ -1,0 +1,70 @@
+import json
+import sys
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).parent))
+from compute_metrics import compute_metrics
+
+csv_path = sys.argv[1]
+params_path = sys.argv[2]
+report_html = sys.argv[3]
+top_designs_csv = sys.argv[4]
+
+with open(params_path) as f:
+    run_config = json.load(f)
+
+results_dir = Path(run_config.pop("results_dir")).resolve()
+
+run_id = datetime.now().strftime("%Y%m%d_%H%M%S") + "_" + uuid.uuid4().hex[:6]
+
+metrics = compute_metrics(csv_path)
+overall = metrics["overall"]
+
+flat_params = {}
+for group, group_val in run_config.items():
+    if isinstance(group_val, dict):
+        for k, v in group_val.items():
+            flat_params[f"{group}_{k}"] = v
+    else:
+        flat_params[group] = group_val
+
+def make_row(run_id, sequence_length, metric_dict, flat_params):
+    return {
+        "run_id": run_id,
+        "sequence_length": sequence_length,
+        "sequence_count": metric_dict["target_fold_count"],
+        "pct_target_fold": metric_dict["pct_target_fold"],
+        "pct_target_fold_high_conf": metric_dict["pct_target_fold_high_conf"],
+        "mean_probability": metric_dict["mean_probability"],
+        "median_probability": metric_dict["median_probability"],
+        **flat_params,
+    }
+
+rows = [make_row(run_id, "overall", overall, flat_params)]
+for length, length_metrics in metrics["per_length"].items():
+    rows.append(make_row(run_id, length, length_metrics, flat_params))
+
+experiments_csv = results_dir / "experiments.csv"
+new_rows = pd.DataFrame(rows)
+if experiments_csv.exists():
+    existing = pd.read_csv(experiments_csv)
+    combined = pd.concat([existing, new_rows], ignore_index=True)
+else:
+    combined = new_rows
+combined.to_csv(experiments_csv, index=False)
+
+import shutil
+
+artifacts_dir = results_dir / "artifacts" / run_id
+artifacts_dir.mkdir(parents=True, exist_ok=True)
+shutil.copy(csv_path, artifacts_dir / "classifications.csv")
+shutil.copy(report_html, artifacts_dir / "report.html")
+shutil.copy(top_designs_csv, artifacts_dir / "top_designs.csv")
+
+print(f"run_id:    {run_id}")
+print(f"Artifacts: {artifacts_dir}")
+print(f"Logged to: {experiments_csv}")


### PR DESCRIPTION
This PR
- Introduces lightweight **CSV-based experiment tracking**.
- Stores run artifacts in `results/artifacts/<run_id>/`.
- Logs experiment metadata, parameters, and metrics to a global `experiments.csv` file for easy cross-run comparison.
- Adds a notebook for experiment analysis and result exploration.